### PR TITLE
Ensure individual pools per type classes

### DIFF
--- a/src/classes/MessageType.ts
+++ b/src/classes/MessageType.ts
@@ -140,10 +140,6 @@ export default class MessageType {
    * Claim an instance of this class (or create one if none are available).
    */
   public static claim<T extends MessageType>() {
-    if (!this.pool) {
-      this.pool = new Array()
-    }
-
     if (this.pool.length > 0) {
       return this.pool.shift() as T
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,7 @@ export default function generateTypeDecorator<I extends number>(
       }
 
       target.id = id
+      target.pool = new Array()
       typesRegister.set(id, target as any)
 
       const { prototype, attributes, size } = target as any

--- a/test/classes/MessageType/pool.ts
+++ b/test/classes/MessageType/pool.ts
@@ -1,6 +1,8 @@
 import * as assert from 'assert'
 
 import Leave from 'test/types/Leave'
+import Move from 'test/types/Move'
+import Moved from 'test/types/Moved'
 
 describe('pool', () => {
   it('Can reuse released object instances', () => {
@@ -9,5 +11,17 @@ describe('pool', () => {
 
     const newInstance = Leave.create({ time: 1 }) as any
     assert.equal(newInstance.__reused, true)
+  })
+
+  it('Each types has a separate pool regardless of inheritance', () => {
+    const move = Move.create({} as any)
+    const moved = Moved.create({} as any)
+    move.release()
+
+    assert.equal(Move.pool.length, 1)
+    assert.equal(Moved.pool.length, 0)
+
+    assert(moved instanceof Moved)
+    assert.notDeepEqual(move.constructor.name, moved.constructor.name)
   })
 })


### PR DESCRIPTION
Create a new Array for each type classes upon registration instead
of creating them lazily. This has the benefit of correcting an issue
where the arrays' content was shared through inheriting classes.