### PR TITLE
Fix webpack build

### DIFF
--- a/src/classes/MessageType.ts
+++ b/src/classes/MessageType.ts
@@ -1,3 +1,5 @@
+import '../register'
+
 /**
  * Type attributes contain the information
  */


### PR DESCRIPTION
Webpack build failed because IContextualRequire was not defined in MessageType.ts